### PR TITLE
test: update global training config to use multiple output steps

### DIFF
--- a/tests/system-level/anemoi_test/configs/training/global/training_config.yaml
+++ b/tests/system-level/anemoi_test/configs/training/global/training_config.yaml
@@ -391,7 +391,8 @@ training:
 
   precision: 16-mixed
 
-  multistep_input: 2
+  multistep_input: 3
+  multistep_output: 2
 
   accum_grad_batches: 1
 
@@ -439,7 +440,7 @@ training:
         # loss class to initialise
         _target_: anemoi.training.losses.MSELoss
         # Scalers to include in loss calculation
-        scalers: ['pressure_level', 'general_variable', 'nan_mask_weights', 'node_weights']
+        scalers: ['pressure_level', 'general_variable', 'nan_mask_weights', 'node_weights', 'output_steps']
         ignore_nans: False
 
   validation_metrics:
@@ -530,3 +531,8 @@ training:
           nodes_name: ${graph.data}
           nodes_attribute_name: area_weight
           norm: unit-sum
+
+        output_steps:
+          _target_: anemoi.training.losses.scalers.TimeStepScaler
+          norm: "unit-sum"
+          weights: [1.0, 2.0]


### PR DESCRIPTION
## Description
This is to update the training config for the global training task to use 2 output steps. This covers the change and functionality introduced in https://github.com/ecmwf/anemoi-core/pull/636 and https://github.com/ecmwf/anemoi-inference/pull/380

Only to be merged when 
- [x] the other PRs are merged
- [ ] the test suite with the new configuration runs successfully


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
