### PR TITLE
ci: Update ecflow log directory

### DIFF
--- a/tests/system-level/configs/host.yaml
+++ b/tests/system-level/configs/host.yaml
@@ -1,7 +1,7 @@
 host:
   hostname: "hpc"
   user: "{USER}"
-  log_directory: "%ECF_HOME%"
+  log_directory: "/lus/h1resw02/project/prepml/ecflow_server/logs"
   workdir: "$TMPDIR"
   submit_arguments:
     defaults:


### PR DESCRIPTION
## Description
For prepml we started putting the job logs in the Lustre project folder instead of in the home folder. Since the system tests here are sharing the prepml ecflow infrastructure, we should put the logs in the same place. 

Tested with the on-demand test that logs go to the new place.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
