### PR TITLE
feat: Add Teams notification to nightly workflow

### DIFF
--- a/.github/workflows/nightly_ci_hpc.yaml
+++ b/.github/workflows/nightly_ci_hpc.yaml
@@ -49,3 +49,33 @@ jobs:
       troika_user: ${{ secrets.HPC_SYSTEM_TEST_USER }}
       ecflow_host: ${{ secrets.HPC_SYSTEM_TEST_HOST }}
       ecflow_port: ${{ secrets.HPC_SYSTEM_TEST_PORT }}
+
+  notify-failure:
+    if: failure()
+    runs-on: ubuntu-latest
+    needs: system_level_test
+    name: Notify failure
+    steps:
+      - uses: jdcargile/ms-teams-notification@v1.4
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI_TEST }}
+          notification-summary: ❌ Nightly anemoi system level tests failed!
+          notification-color: dc3545
+          timezone: Europe/Paris
+          verbose-logging: true
+
+  notify-success:
+    if: success()
+    runs-on: ubuntu-latest
+    needs: system_level_test
+    name: Notify success
+    steps:
+      - uses: jdcargile/ms-teams-notification@v1.4
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI_TEST }}
+          notification-summary: ✅ Nightly anemoi system level tests succeeded!
+          notification-color: 17a2b8
+          timezone: Europe/Paris
+          verbose-logging: true


### PR DESCRIPTION
## Description
Send a notification to a Teams channel with the status of the nightly system level tests (fail or success).

##  Additional notes ##

- this action is used: [jdcargile/ms-teams-notification@v1.4 ](https://github.com/jdcargile/ms-teams-notification)
- Uses the MS_TEAMS_WEBHOOK_URI_TEST that define the Teams channel to be used
- To create an incoming webhook:
  - Click on the "..." button for a channel
  - -> Manage channel 
  - -> Edit connectors
  - -> Incoming Webhook
  - -> Copy the content in the MS_TEAMS_WEBHOOK_URI_TEST secret
  

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
