### PR TITLE
test: update suite dirs

### DIFF
--- a/tests/system-level/configs/host.yaml
+++ b/tests/system-level/configs/host.yaml
@@ -1,7 +1,7 @@
 host:
   hostname: "hpc"
   user: "{USER}"
-  log_directory: "/lus/h1resw02/project/prepml/ecflow_server/logs"
+  log_directory: "{OUTPUT_ROOT_SUITE}/logs"
   workdir: "$TMPDIR"
   submit_arguments:
     defaults:

--- a/tests/system-level/configs/user.yaml
+++ b/tests/system-level/configs/user.yaml
@@ -22,12 +22,12 @@ ecflow_server:
 # the variables. Be careful with the order of the variables and the order of the configuration files,
 # as the variables will be overriden if they have the same name.
 
-OUTPUT_ROOT_SUITE: "/lus/h1resw02/project/prepml/ecflow_server/workdirs"
+OUTPUT_ROOT_SUITE: "/lus/h1resw02/project/prepml/ecflow_server"
 # For the ci workflow, the output root is the prepml workdir so that it is in the same place as prepml suites
 # and can share the same uv cache.
 
 ecflow_variables:
-  OUTPUT_ROOT: "{OUTPUT_ROOT_SUITE}/testing/{group}/{name}"
+  OUTPUT_ROOT: "{OUTPUT_ROOT_SUITE}/workdirs/testing/{group}/{name}"
   LIB_DIR: "%OUTPUT_ROOT%/local"
   DATA_DIR: "%OUTPUT_ROOT%/data"
   RESULTS_DIR: "%OUTPUT_ROOT%/results"


### PR DESCRIPTION
## Description
Make the log directory relative to `OUTPUT_ROOT_SUITE` so that users can still run the suite locally as described in the README, for purposes of debugging. The directories used by the suite in the ci workflow do not change.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
