### PR TITLE
docs: Update DOC about PRs

### DIFF
--- a/.github/workflows/readthedocs-pr-update.yml
+++ b/.github/workflows/readthedocs-pr-update.yml
@@ -22,3 +22,15 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "anemoi"
+
+  documentation-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install .
+      - name: Build documentation (warnings as errors)
+        run: sphinx-build -W docs/ docs/_build/html

--- a/.github/workflows/readthedocs-pr-update.yml
+++ b/.github/workflows/readthedocs-pr-update.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Install dependencies
         run: pip install .
       - name: Build documentation (warnings as errors)
-        run: sphinx-build -W docs/ docs/_build/html
+        run: sphinx-build -W --keep-going docs/ docs/_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,37 +70,37 @@ extensions = [
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "'**.ipynb_checkpoints'"]
 
 intersphinx_mapping = {
-    "python": ("https://python.readthedocs.io/en/latest", None),
+    "python": ("https://docs.python.org/3/", None),
     "anemoi-utils": (
-        "https://anemoi-utils.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/utils/en/latest/",
         ("../../anemoi-utils/docs/_build/html/objects.inv", None),
     ),
     "anemoi-datasets": (
-        "https://anemoi-datasets.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/datasets/en/latest/",
         ("../../anemoi-datasets/docs/_build/html/objects.inv", None),
     ),
     "anemoi-models": (
-        "https://anemoi-models.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/models/en/latest/",
         ("../../anemoi-models/docs/_build/html/objects.inv", None),
     ),
     "anemoi-training": (
-        "https://anemoi-training.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/training/en/latest/",
         ("../../anemoi-training/docs/_build/html/objects.inv", None),
     ),
     "anemoi-inference": (
-        "https://anemoi-inference.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/inference/en/latest/",
         ("../../anemoi-inference/docs/_build/html/objects.inv", None),
     ),
     "anemoi-graphs": (
-        "https://anemoi-graphs.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/graphs/en/latest/",
         ("../../anemoi-graphs/docs/_build/html/objects.inv", None),
     ),
     "anemoi-registry": (
-        "https://anemoi-registry.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/registry/en/latest/",
         ("../../anemoi-registry/docs/_build/html/objects.inv", None),
     ),
     "anemoi-transform": (
-        "https://anemoi-transform.readthedocs.io/en/latest/",
+        "https://anemoi.readthedocs.io/projects/transform/en/latest/",
         ("../../anemoi-transform/docs/_build/html/objects.inv", None),
     ),
 }

--- a/docs/contributing/code_style.rst
+++ b/docs/contributing/code_style.rst
@@ -88,7 +88,8 @@ Place new files in the appropriate package directory:
 
 .. note::
 
-Utility Functions Organization:
+   Utility Functions Organization:
+
    -  Use ``utils.py`` only for package-specific helper functions that
       don't fit in other modules.
 

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -88,11 +88,15 @@ before enabling automated checks.
 #. After an initial review, a maintainer will enable automated checks to
    run on the Pull Request.
 
+#. It is the sole responsibility of the respective contributor to keep the PR
+   in sync with the target branch (e.g., :code:`git pull origin main`)
+   and to address any merge conflicts that may arise.
+
 #. Reviewers may leave feedback or request changes. To confirm that
    feedback has been addressed, ask reviewers to mark their comments as
    resolved.
 
-#. Once approved, the Pull Request will be merged into the appropiate
+#. Once approved, the Pull Request will be merged into the appropriate
    branch according to the :ref:`merging-guidelines`
 
 .. _inactive-issue-process:

--- a/docs/contributing/guidelines.rst
+++ b/docs/contributing/guidelines.rst
@@ -104,7 +104,7 @@ Examples of PRs that should be labeled ``ATS Approval Needed``:
 Examples of PRs that can be labeled ``ATS Approval Not Needed``:
 ----------------------------------------------------------------
 
--  Hotfixes and general bug fixes [*]_
+-  Hotfixes and general bug fixes [1]_
 
 -  A minor new feature such as:
 
@@ -114,11 +114,11 @@ Examples of PRs that can be labeled ``ATS Approval Not Needed``:
    -  New filter in `anemoi-transform`
    -  New grid types in `anemoi-graphs`
 
--  Extensions to testing or CI infrastructure [*]_
+-  Extensions to testing or CI infrastructure [1]_
 
--  PRs addressing technical debt [*]_
+-  PRs addressing technical debt [1]_
 
-.. [*]
+.. [1]
 
    Assuming those do not imply any breaking changes or dependency changes
    as explained above

--- a/docs/contributing/guidelines.rst
+++ b/docs/contributing/guidelines.rst
@@ -272,8 +272,9 @@ When submitting Pull Requests (PRs), please follow these guidelines:
 Once a PR has been reviewed, approved, and the appropriate label is in place, the
 following merging rules apply:
 
--  For PRs labeled ``ATS Approval Not Needed``: The PR can be merged by
-   the author of the PR. For external contributors, who cannot merge their own PRs,
+-  For PRs labeled ``ATS Approval Not Needed``: The PR is merged by
+   the author of the PR, unless otherwise stated.
+   For external contributors, who cannot merge their own PRs,
    the PR is merged by a reviewer, after the author has stated that the PR is ready to be merged.
 
 -  For PRs labeled ``ATS Approved``: These PRs will be merged by the

--- a/docs/contributing/guidelines.rst
+++ b/docs/contributing/guidelines.rst
@@ -269,12 +269,12 @@ When submitting Pull Requests (PRs), please follow these guidelines:
  Pull Request Merging Guidelines
 *********************************
 
-Once a PR has been reviewed and the appropriate label is in place, the
+Once a PR has been reviewed, approved, and the appropriate label is in place, the
 following merging rules apply:
 
 -  For PRs labeled ``ATS Approval Not Needed``: The PR can be merged by
-   the reviewer once it has been approved, provided the reviewer is not
-   the original contributor.
+   the author of the PR. For external contributors, who cannot merge their own PRs,
+   the PR is merged by a reviewer, after the author has stated that the PR is ready to be merged.
 
 -  For PRs labeled ``ATS Approved``: These PRs will be merged by the
    ``@anemoisecurity`` group after they have been reviewed in the ATS

--- a/docs/contributing/guidelines.rst
+++ b/docs/contributing/guidelines.rst
@@ -269,23 +269,45 @@ When submitting Pull Requests (PRs), please follow these guidelines:
  Pull Request Merging Guidelines
 *********************************
 
-Once a PR has been reviewed, approved, and the appropriate label is in place, the
-following merging rules apply:
+General Rule
+============
 
--  For PRs labeled ``ATS Approval Not Needed``: The PR is merged by
-   the author of the PR, unless otherwise stated.
-   For external contributors, who cannot merge their own PRs,
-   the PR is merged by a reviewer, after the author has stated that the PR is ready to be merged.
+Once a PR has been reviewed, approved, and the appropriate label is in place,
+it can be merged by either the contributor or by the reviewer,
+if the contributor has explicitly stated that the PR is ready to be merged.
 
--  For PRs labeled ``ATS Approved``: These PRs will be merged by the
-   ``@anemoisecurity`` group after they have been reviewed in the ATS
-   meeting and marked with the ``ATS Approved`` label.
+Exceptions and Special Cases
+============================
+
+**Label: ATS Approval Needed**
+
+- Must not be merged until reviewed in the ATS
+
+- Label must be updated to ATS Approved before merging
+
+**Multiple Reviewers Requested**
+
+- The merging reviewer must confirm that all required approvals are received,
+  or that each requested reviewer has given explicit approval
+
+**No Merge Permissions**
+
+- If you can't merge your own approved PR, ask a reviewer or tag @anemoisecuritygroup
+
 
 .. note::
 
    PRs that do not have either label **must not be merged**. When in
    doubt, apply the ``ATS Approval Needed`` label or consult
    ``@anemoisecurity`` for guidance.
+
+.. note::
+
+   This is a highly collaborative project, where explicit communication helps
+   reduce conflicts and misunderstandings. When in doubt, ask before merging. Reach
+   out via GitHub comments or other communication channels to confirm with
+   contributors and reviewers. If there is uncertainty or conflict, tag the
+   ``@anemoisecurity`` group for guidance.
 
 ***************
  Documentation

--- a/docs/getting-started/tour.rst
+++ b/docs/getting-started/tour.rst
@@ -16,8 +16,8 @@ through the Anemoi framework.
 *********************************************
 
 If you would like to make predictions with a model that has already been
-trained, e.g. AIFS Single 1. See the :ref:`anemoi-inference getting
-started guide <anemoi-inference:usage-getting-started>`.
+trained, e.g. AIFS Single 1. See the :ref:`anemoi-inference quickstart
+guide <anemoi-inference:usage-quickstart>`.
 
 ********************************************
  Training a new model through configuration
@@ -34,8 +34,8 @@ of building blocks which already exist in the Anemoi codebase. See the
 
 If you would like to go beyond training a model with a sample dataset,
 e.g. building a new dataset to train a model using new data. See the
-:ref:`anemoi-datasets getting started guide
-<anemoi-datasets:usage-getting-started>`.
+:ref:`anemoi-datasets guide for using an existing dataset
+<anemoi-datasets:using-introduction>`.
 
 ************************
  Contributing use-cases

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,23 +34,23 @@ Possible uses of *Anemoi* are for developing:
 -  Downscaling models
 -  Ensemble/probabilistic models
 
-#########
+######################################
  What is it for, and what is it not?
-#########
+######################################
 Anemoi started out as a codebase for building data-driven weather forecasting models. Since then, it has evolved to include additional *tasks*, such as downscaling (superresolution), time interpolation (temporal downscaling), and autoencoding. What these applications share is the need to build models in which information must be gathered, exchanged, and processed across the spatial dimension. For these use cases, scalable and parallelisable graph and transformer tooling is particularly valuable.
 
 Anemoi is not intended to address all Earth-system ML problems. Problems that focus on strictly local networks or on processing long temporal signals (e.g. LSTMs) share little in common with Anemoi’s current focus, and the framework is therefore unlikely to provide significant benefits for those use cases.
 
-#########
+################
  Who is it for?
-#########
+################
 Anemoi’s primary developers are based in operational meteorological centres, where it is used to create operational data-driven models. Many of these developers are also users of the framework, building and deploying models in practice. This user group places a strong emphasis on structure and reproducibility, in particular the ability to recreate the *same* model as Anemoi evolves and expands.
 
 Anemoi also aims to serve the wider research community by enabling users to test new methods for training data-driven forecasting systems. This user group places greater emphasis on flexibility, allowing ideas to be easily adapted and tested.
 
-#########
+##########
  License
-#########
+##########
 
 *Anemoi* is available under the open source `Apache License`__.
 


### PR DESCRIPTION
- [ ] I would like to harden the doc build to fail upon broken links. @anaprietonem 

## Description

Clarifies the responsibility for merging PRs.

Fixes a few errors and warnings in the doc.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi start -->
----
📚 Documentation preview 📚: https://anemoi--125.org.readthedocs.build/en/125/

<!-- readthedocs-preview anemoi end -->