### PR TITLE
ci: fix wellies module versions

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -40,7 +40,6 @@ runs:
 
           # Load modules of interest
           module load ecflow
-          module load wellies
 
           # Clone the repository
           PACKAGE_NAME=anemoi

--- a/.github/workflows/system_level_test.yaml
+++ b/.github/workflows/system_level_test.yaml
@@ -105,7 +105,7 @@ jobs:
             echo "Job is running on ${{ runner.os }}"
 
             # Load modules of interest
-            module load python/3.11.10-01
+            module load python3/3.11.10-01
             module load wellies/1.2.0
 
             mkdir -p /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}

--- a/.github/workflows/system_level_test.yaml
+++ b/.github/workflows/system_level_test.yaml
@@ -108,7 +108,7 @@ jobs:
             module load wellies/1.2.0
 
             mkdir -p /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}
-            /home/mlx/bin/tracksuite-print /anemoi_tests/${{ inputs.suite_name }} --host ${{ secrets.ecflow_host }} -f html &> /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}/summary.md
+            /home/mlx/bin/tracksuite-print /anemoi_tests/${{ inputs.suite_name }} --host ${{ secrets.ecflow_host }} --port ${{ secrets.ecflow_port }} -f html |& tee /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}/summary.md
           sbatch_options: |
             #SBATCH --job-name=anemoi_test_print_results
             #SBATCH --time=00:10:00

--- a/.github/workflows/system_level_test.yaml
+++ b/.github/workflows/system_level_test.yaml
@@ -105,6 +105,7 @@ jobs:
             echo "Job is running on ${{ runner.os }}"
 
             # Load modules of interest
+            module load python/3.11.10-01
             module load wellies/1.2.0
 
             mkdir -p /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}

--- a/.github/workflows/system_level_test.yaml
+++ b/.github/workflows/system_level_test.yaml
@@ -105,8 +105,7 @@ jobs:
             echo "Job is running on ${{ runner.os }}"
 
             # Load modules of interest
-            module load python3/3.11.10-01
-            module load wellies/1.2.0
+            module load wellies/1.3.0
 
             mkdir -p /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}
             /home/mlx/bin/tracksuite-print /anemoi_tests/${{ inputs.suite_name }} --host ${{ secrets.ecflow_host }} -f html |& tee /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}/summary.md

--- a/.github/workflows/system_level_test.yaml
+++ b/.github/workflows/system_level_test.yaml
@@ -108,7 +108,7 @@ jobs:
             module load wellies/1.2.0
 
             mkdir -p /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}
-            /home/mlx/bin/tracksuite-print /anemoi_tests/${{ inputs.suite_name }} --host ${{ secrets.ecflow_host }} --port ${{ secrets.ecflow_port }} -f html |& tee /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}/summary.md
+            /home/mlx/bin/tracksuite-print /anemoi_tests/${{ inputs.suite_name }} --host ${{ secrets.ecflow_host }} -f html |& tee /scratch/${{ secrets.troika_user }}/anemoi_tests/${{ inputs.suite_name }}/summary.md
           sbatch_options: |
             #SBATCH --job-name=anemoi_test_print_results
             #SBATCH --time=00:10:00

--- a/tests/system-level/build.sh
+++ b/tests/system-level/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+module load python3
+module load ecflow
 module load wellies/${WELLIES_VERSION:-1.2.0}
 module list
 

--- a/tests/system-level/configs/tools.yaml
+++ b/tests/system-level/configs/tools.yaml
@@ -65,7 +65,7 @@ tools:
         depends: [python]
       inference_env:
         type: venv
-        packages: [anemoi_inference, anemoi_models, anemoi_transform]
+        packages: [anemoi_inference, anemoi_utils, anemoi_models, anemoi_transform]
         depends: [python]
 
   # --------Environment variables -----------------------------------------


### PR DESCRIPTION
## Description
The ci workflow for the system-level tests is failing when trying to load wellies in the deploy script. This PR fixes the wellies module version.

Run with successful deployment of the test suite here: https://github.com/ecmwf/anemoi/actions/runs/25561451462/job/75033864953

Looks like the print step also needs fixing..

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
