### PR TITLE
test: update config to rescale tp in cerra dataset

### DIFF
--- a/tests/system-level/anemoi_test/configs/datasets/cerra-rr-an-oper-0001-mars-5p5km-2017-2017-6h-v3-testing/dataset_config.yaml
+++ b/tests/system-level/anemoi_test/configs/datasets/cerra-rr-an-oper-0001-mars-5p5km-2017-2017-6h-v3-testing/dataset_config.yaml
@@ -44,18 +44,24 @@ input:
       - msl
       stream: oper
       type: an
-  - accumulate:
-      period: 6h
-      availability: auto
-      source:
-        mars:
-          class: rr
-          levtype: sfc
-          origin: se-al-ec
-          param:
-          - tp
-          - sf
-          stream: oper
+  - pipe:
+    - accumulate:
+        period: 6h
+        availability: auto
+        source:
+          mars:
+            class: rr
+            levtype: sfc
+            origin: se-al-ec
+            param:
+            - tp
+            - sf
+            stream: oper
+    - rescale:
+        param: tp
+        scale: 0.001
+        offset: 0.0
+
   - constants:
       param:
       - cos_latitude


### PR DESCRIPTION
## Description
This PR adds a rescale filter to the config for creating the cerra test dataset in order to rescale tp from mm to m.

Successful test run of the training tasks here: https://github.com/ecmwf/anemoi/actions/runs/26450886084

## What problem does this change solve?
Since unit checks were introduced in anemoi-transform, the lam training case errors when opening the dataset (which joins era and cerra, which have incompatible units for tp).

##  Additional notes ##
Failing test suite: https://github.com/ecmwf/anemoi/actions/runs/26259010729
```
raise ValueError(f"Variables are not compatible: {'; '.join(reasons)}")
ValueError: Variables are not compatible: tp: Units are not compatible: kg m**-2 vs m
```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
